### PR TITLE
fix: Compound borrow action

### DIFF
--- a/python/coinbase-agentkit/changelog.d/496.bugfix.md
+++ b/python/coinbase-agentkit/changelog.d/496.bugfix.md
@@ -1,0 +1,1 @@
+Fixed Compound borrow action

--- a/python/coinbase-agentkit/coinbase_agentkit/action_providers/compound/compound_action_provider.py
+++ b/python/coinbase-agentkit/coinbase_agentkit/action_providers/compound/compound_action_provider.py
@@ -275,9 +275,7 @@ Important notes:
         try:
             validated_args = CompoundBorrowSchema(**args)
             comet_address = self._get_comet_address(wallet_provider.get_network())
-            base_token_address = get_base_token_address(
-                wallet_provider.get_network(), comet_address
-            )
+            base_token_address = get_base_token_address(wallet_provider, comet_address)
             base_token_decimals = get_token_decimals(wallet_provider, base_token_address)
 
             # Convert human-readable amount to atomic amount


### PR DESCRIPTION
Removes a call to `get_network()` which is not needed for the `get_base_token_address` call.

## Description

Resolves: #496 

## Tests
```
Prompt: Borrow 0.01 USDC from compound

-------------------
Borrowed 0.01 USDC from Compound. Transaction hash: 0x12d060fd4748ce6d5dfd8bcb6f4f9e57c761b449af18992fd7f1409ec6ddc62a Health ratio changed from Infinity to 21.56
-------------------
You have successfully borrowed 0.01 USDC from Compound. The transaction hash is: 0x12d060fd4748ce6d5dfd8bcb6f4f9e57c761b449af18992fd7f1409ec6ddc62a.

Your health ratio is now at 21.56. If you need further assistance, feel free to ask!
-------------------

```
## Checklist

A couple of things to include in your PR for completeness:

- [ ] Added documentation to all relevant README.md files
- [x] Added a changelog entry